### PR TITLE
Update squirrel

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -243,7 +243,7 @@ process squirrel {
     """
     export XDG_CACHE_HOME=\$PWD/.cache
     squirrel --version 2>&1 | sed 's/: /,/' > squirrel.version
-    squirrel "all_consensus.fasta" -o squirrel --no-mask --seq-qc --outfile all_consensus.aln.fasta --tempdir squirrel_tmp -t ${task.cpus} $params._squirrel_options
+    squirrel "all_consensus.fasta" -o squirrel --no-mask --seq-qc --outfile all_consensus.aln.fasta --tempdir squirrel_tmp -t ${task.cpus} --clade ${params.clade} $params._squirrel_options
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -342,7 +342,7 @@ workflow pipeline {
                     artic.consensus,
                     artic.amplicon_depths,
                     artic.raw_bam.flatMap { it -> [ it[0], it[1] ] },
-                    squirrel.out.alignment,
+                    squirrel.out.alignment.flatMap { it -> [ it ] },
                     squirrel.out.all.flatMap { it -> [ it ] },
                     )
             } else {

--- a/main.nf
+++ b/main.nf
@@ -235,7 +235,7 @@ process squirrel {
     input:
         path "all_consensus.fasta"
     output:
-        path "squirrel/all_consensus.aln.fasta", emit: alignment
+        path "squirrel/all_consensus*.aln.fasta", emit: alignment
         path "squirrel", emit: all
         path "squirrel.version", emit: version
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -91,9 +91,9 @@ process {
         conda     = "bioconda::artic=1.7.3"
     }
     withLabel: squirrel {
-        container = "community.wave.seqera.io/library/squirrel:1.1.5--b41340e6d2ba2b30"
+        container = "community.wave.seqera.io/library/squirrel:1.1.6--d7435d8c5b738aff"
         memory    = '2G'
-        conda     = "bioconda::squirrel=1.1.5"
+        conda     = "bioconda::squirrel=1.1.6"
     }
     shell = ['/bin/bash', '-euo', 'pipefail']
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -91,9 +91,9 @@ process {
         conda     = "bioconda::artic=1.7.3"
     }
     withLabel: squirrel {
-        container = "articnetworkorg/squirrel@sha256:6311a61f667fa288b7ede67e88f4b7451e31f8b1da3ac61c5d1c8f303e253591"
+        container = "community.wave.seqera.io/library/squirrel:1.1.5--b41340e6d2ba2b30"
         memory    = '2G'
-        conda     = "bioconda::squirrel=1.0.12"
+        conda     = "bioconda::squirrel=1.1.5"
     }
     shell = ['/bin/bash', '-euo', 'pipefail']
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -109,13 +109,15 @@
           "type": "string",
           "title": "Clade",
           "description": "Specify whether the sequencing run is primarily `cladeI` or `cladeII`.",
+          "default": "split",
           "enum": [
             "cladei",
             "cladeia",
             "cladeib",
             "cladeii",
             "cladeiia",
-            "cladeiib"
+            "cladeiib",
+            "split"
           ],
           "help_text": ""
         },
@@ -134,7 +136,7 @@
         "squirrel_options": {
           "type": "string",
           "hidden": "true",
-          "description": "Pass options to Squirrel, for example \"--clade cladeii\"."
+          "description": "Pass options to Squirrel, for example \"--run-phylo\"."
         }
       },
       "required": [


### PR DESCRIPTION
- bumps squirrel version to 1.1.5
- actually passes the clade parameter to squirrel
- adds `split` as the default option for the clade (previously cladeii)